### PR TITLE
Add proper docker image building and deployment script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# Note cargo need .git etc to determine source revision
+# .git
+# .gitignore
+# .gitattributes
+
+# Github
+.github
+
+# Docker
+Dockerfile
+docker-compose.yml
+.dockerignore
+
+# Documentation
+README.md
+CHANGELOG.md
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+SECURITY.md
+
+# macOS (optional)
+.DS_Store
+
+# Visual Studio Code (optional)
+.vscode
+
+# Cargo build artifacts
+/target/
+/.cargo-home
+
+# Persistent node data storage
+/.node-data

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,10 +5,12 @@
 
 # Github
 .github
+/deploy/
 
 # Docker
 Dockerfile
 docker-compose.yml
+docker-compose.dev.yml
 .dockerignore
 
 # Documentation

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM docker.io/paritytech/ci-linux:production as builder
+
+WORKDIR /zhenxunge
+COPY . /zhenxunge
+ENV CARGO_HOME /zhenxunge/.cargo-home
+RUN --mount=type=cache,target=/zhenxunge/.cargo-home \
+    --mount=type=cache,target=/zhenxunge/target \
+    cargo build --locked --release && install -Dt ./bin/ target/release/node-swap
+
+# This is the 2nd stage: a very small image where we copy the zhenxunge node binary."
+FROM docker.io/library/ubuntu:20.04
+LABEL description="Zhenxunge node"
+
+COPY --from=builder /zhenxunge/bin/ /usr/local/bin/
+
+RUN useradd -m -u 1000 -U -s /bin/sh -d /zhenxunge zhenxunge && \
+	mkdir -p /data /zhenxunge/.local/share && \
+	chown -R zhenxunge:zhenxunge /data /zhenxunge && \
+	ln -s /data /zhenxunge/.local/share/node-swap && \
+# Sanity checks
+	/usr/local/bin/node-swap --version
+
+USER zhenxunge
+EXPOSE 30333 9933 9944 9615
+VOLUME ["/data"]
+ENTRYPOINT "/usr/local/bin/node-swap"
+CMD ["--dev", "--ws-external"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,5 @@ RUN useradd -m -u 1000 -U -s /bin/sh -d /zhenxunge zhenxunge && \
 USER zhenxunge
 EXPOSE 30333 9933 9944 9615
 VOLUME ["/data"]
-ENTRYPOINT "/usr/local/bin/node-swap"
+ENTRYPOINT ["/usr/local/bin/node-swap"]
 CMD ["--dev", "--ws-external"]

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 see www.delphinuslab.com for details
 
-# Running
+# Running a smallish network for development
 
 We use [buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/) to facilitate docker image building. Cargo caches are stored locally. So that we can incrementally build docker images.
 
 ```
-DOCKER_BUILDKIT=1 docker-compose up
+DOCKER_BUILDKIT=1 docker build . -t zhenxunge-node
+docker-compose -f docker-compose.dev.yml up
 ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Delphinus Node
 
 see www.delphinuslab.com for details
+
+# Running
+
+We use [buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/) to facilitate docker image building. Cargo caches are stored locally. So that we can incrementally build docker images.
+
+```
+DOCKER_BUILDKIT=1 docker-compose up
+```

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ We use [buildkit](https://docs.docker.com/develop/develop-images/build_enhanceme
 
 Running the following to deploy a node on remote host `remote-host`.
 ```
-./deploy/deploy.sh -m ubuntu@remote-host
+./deploy/deploy.sh -m ubuntu@remote-host -d test.example.com
 ```
 
+The RPC server can be accessed via `wss://test.example.com`, if `test.example.com` is pointed to `remote-host`.
+The TLS certificate is obtained automatically with [caddy](https://caddyserver.com/).
 Run `./deploy/deploy.sh -h` for more options.
 
 ## Running a smallish network for development

--- a/README.md
+++ b/README.md
@@ -2,11 +2,21 @@
 
 see www.delphinuslab.com for details
 
-# Running a smallish network for development
-
+# Running and Deployment
 We use [buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/) to facilitate docker image building. Cargo caches are stored locally. So that we can incrementally build docker images.
+
+## Deploy node to remote host
+
+Running the following to deploy a node on remote host `remote-host`.
+```
+./deploy/deploy.sh -m ubuntu@remote-host
+```
+
+Run `./deploy/deploy.sh -h` for more options.
+
+## Running a smallish network for development
 
 ```
 DOCKER_BUILDKIT=1 docker build . -t zhenxunge-node
-docker-compose -f docker-compose.dev.yml up
+docker-compose -f deploy/dev/docker-compose.yml up
 ```

--- a/deploy/caddy/docker-compose.yml
+++ b/deploy/caddy/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3.7"
+services:
+  caddy:
+    image: lucaslorentz/caddy-docker-proxy:ci-alpine
+    ports:
+      - 80:80
+      - 443:443
+    environment:
+      - CADDY_INGRESS_NETWORKS=caddy
+    networks:
+      - caddy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - caddy-data:/data
+    restart: unless-stopped
+
+  node:
+    labels:
+      caddy: ${NODE_DOMAIN:-localhost}
+      caddy.reverse_proxy: "{{upstreams 9944}}"
+    image: zhenxunge-node
+    networks:
+      - caddy
+    ports:
+      - "9944:9944"
+    volumes:
+      - zhenxunge-node-data:/data
+    restart: unless-stopped
+
+networks:
+  caddy:
+    external: true
+
+volumes:
+  zhenxunge-node-data:
+  caddy-data:

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -ueo pipefail
+
+local_repo_path="$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)"
+machine="${DEPLOY_MACHINE:-}"
+repo="${DEPLOY_REPO:-$local_repo_path}"
+private_key_file="${DEPLOY_PRIVATE_KEY_FILE:-}"
+dry_run=
+verbose=
+logs_only=
+
+function usage() {
+  cat <<EOF
+deploy.sh deploy node to remote or local machine
+Options
+-m MACHINE             deploy to this machine
+-r REPO                repo path (default: grandparent directory of this file)
+-k PRIVATE_KEY_FILE    set the private key to use
+-h                     show usage
+-l                     follow logs only
+-v                     increase verbosity
+-d, -n                 dry run
+EOF
+}
+
+while getopts "m:r:k:hlvdn-" opt; do
+  case $opt in
+  m)
+    machine="$OPTARG"
+    ;;
+  r)
+    repo="$OPTARG"
+    ;;
+  k)
+    private_key_file="$OPTARG"
+    ;;
+  h)
+    usage
+    exit
+    ;;
+  l)
+    logs_only=y
+    ;;
+  v)
+    verbose=
+    ;;
+  d | n)
+    dry_run=y
+    ;;
+  -)
+    break
+    ;;
+  \?)
+    echo "Invalid option: -$OPTARG" >&2
+    usage
+    exit 1
+    ;;
+  esac
+done
+
+use_ssh="$machine"
+repo_name="$(basename "$repo")"
+repo_path="$local_repo_path"
+if [[ -n "$use_ssh" ]]; then
+  repo_path="$repo_name"
+fi
+
+function quote_command() {
+  python3 -c 'import shlex; import sys; print(shlex.join(sys.argv[1:]))' "$@"
+}
+
+function run_command() {
+  command=("${@}")
+  if [[ -n "$dry_run" ]]; then
+    quote_command "${command[@]}"
+  else
+    if [[ -n "$verbose" ]]; then
+      quote_command "${command[@]}"
+    fi
+    "${command[@]}"
+  fi
+}
+
+function run_maybe_remote_command() {
+  command=("${@}")
+  if [[ -n "$use_ssh" ]]; then
+    # ssh requires a single argument
+    command=(ssh "$machine" "$(quote_command "$@")")
+  fi
+  run_command "${command[@]}"
+}
+
+function copy_repo() {
+  if [[ -z "$use_ssh" ]]; then
+    return
+  fi
+  run_command rsync -avz --progress --exclude target --cvs-exclude -h "$repo/" "$machine:$repo_name/"
+}
+
+function start_node() {
+  run_maybe_remote_command env DOCKER_BUILDKIT=1 docker build "$repo_path" -t zhenxunge-node
+  run_maybe_remote_command docker-compose -f "$repo_path/docker-compose.yml" up -d
+}
+
+function follow_node_logs() {
+  run_maybe_remote_command docker-compose -f "$repo_path/docker-compose.yml" logs -f
+}
+
+function sanity_check() {
+  local_tools=(rsync python3)
+  remote_tools=(docker docker-compose)
+  if ! command -v "${local_tools[@]}" >/dev/null; then
+    echo "You need ${local_tools[*]} installed in the local machine." >&2
+    exit 1
+  fi
+  if ! run_maybe_remote_command command -v "${remote_tools[@]}" >/dev/null; then
+    echo "You need ${remote_tools[*]} installed in the remote machine." >&2
+    exit 1
+  fi
+  run_maybe_remote_command mkdir -p "$repo_name"
+}
+
+function deploy() {
+  sanity_check
+  if [[ -z "$logs_only" ]]; then
+    copy_repo
+    start_node
+  fi
+  follow_node_logs
+}
+
+deploy

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -14,10 +14,9 @@ function usage() {
   cat <<EOF
 deploy.sh deploy node to remote or local machine
 Options
--m MACHINE             deploy to this machine
--d DOMAIN              domain to use for this node
--r REPO                repo path (default: grandparent directory of this file)
--k PRIVATE_KEY_FILE    set the private key to use
+-m MACHINE             deploy to this machine, if not set, deploy locally
+-d DOMAIN              domain to use for rpc service, required for tls certificate
+-r REPO                repo path (default: grandparent directory of this script)
 -h                     show usage
 -l                     follow logs only
 -v                     increase verbosity
@@ -25,7 +24,7 @@ Options
 EOF
 }
 
-while getopts "m:d:r:k:hlvn-" opt; do
+while getopts "m:d:r:hlvn-" opt; do
   case $opt in
   m)
     machine="$OPTARG"
@@ -35,9 +34,6 @@ while getopts "m:d:r:k:hlvn-" opt; do
     ;;
   r)
     repo="$OPTARG"
-    ;;
-  k)
-    private_key_file="$OPTARG"
     ;;
   h)
     usage

--- a/deploy/dev/docker-compose.yml
+++ b/deploy/dev/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.9"
 services:
   node-alice:
     image: zhenxunge-node
+    command: ["--alice", "--dev", "--ws-external"]
     networks:
       - zhenxunge-node
     ports:
@@ -15,6 +16,7 @@ services:
 
   node-bob:
     image: zhenxunge-node
+    command: ["--bob", "--dev", "--ws-external"]
     networks:
       - zhenxunge-node
     ports:
@@ -28,6 +30,7 @@ services:
 
   node-charlie:
     image: zhenxunge-node
+    command: ["--charlie", "--dev", "--ws-external"]
     networks:
       - zhenxunge-node
     ports:

--- a/deploy/dev/docker-compose.yml
+++ b/deploy/dev/docker-compose.yml
@@ -9,10 +9,7 @@ services:
       - "19944:9944"
     volumes:
       - zhenxunge-node-alice-data:/data
-    deploy:
-      restart_policy:
-        condition: on-failure
-        max_attempts: 10
+    restart: unless-stopped
 
   node-bob:
     image: zhenxunge-node
@@ -23,10 +20,7 @@ services:
       - "29944:9944"
     volumes:
       - zhenxunge-node-bob-data:/data
-    deploy:
-      restart_policy:
-        condition: on-failure
-        max_attempts: 10
+    restart: unless-stopped
 
   node-charlie:
     image: zhenxunge-node
@@ -37,10 +31,7 @@ services:
       - "39944:9944"
     volumes:
       - zhenxunge-node-charlie-data:/data
-    deploy:
-      restart_policy:
-        condition: on-failure
-        max_attempts: 10
+    restart: unless-stopped
 
 networks:
   zhenxunge-node:

--- a/deploy/dev/docker-compose.yml
+++ b/deploy/dev/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     networks:
       - zhenxunge-node
     ports:
-      - "9944:9944"
+      - "19944:9944"
     volumes:
       - zhenxunge-node-alice-data:/data
     deploy:
@@ -18,7 +18,7 @@ services:
     networks:
       - zhenxunge-node
     ports:
-      - "19944:9944"
+      - "29944:9944"
     volumes:
       - zhenxunge-node-bob-data:/data
     deploy:
@@ -31,7 +31,7 @@ services:
     networks:
       - zhenxunge-node
     ports:
-      - "29944:9944"
+      - "39944:9944"
     volumes:
       - zhenxunge-node-charlie-data:/data
     deploy:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,48 @@
+version: "3.9"
+services:
+  node-alice:
+    image: zhenxunge-node
+    networks:
+      - zhenxunge-node
+    ports:
+      - "9944:9944"
+    volumes:
+      - zhenxunge-node-alice-data:/data
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 10
+
+  node-bob:
+    image: zhenxunge-node
+    networks:
+      - zhenxunge-node
+    ports:
+      - "19944:9944"
+    volumes:
+      - zhenxunge-node-bob-data:/data
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 10
+
+  node-charlie:
+    image: zhenxunge-node
+    networks:
+      - zhenxunge-node
+    ports:
+      - "29944:9944"
+    volumes:
+      - zhenxunge-node-charlie-data:/data
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 10
+
+networks:
+  zhenxunge-node:
+
+volumes:
+  zhenxunge-node-alice-data:
+  zhenxunge-node-bob-data:
+  zhenxunge-node-charlie-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
 
   node:
     labels:
+      caddy: ${NODE_DOMAIN:-localhost}
       caddy.reverse_proxy: "{{upstreams 9944}}"
     image: zhenxunge-node
     networks:
@@ -28,6 +29,7 @@ services:
 
 networks:
   caddy:
+    external: true
 
 volumes:
   zhenxunge-node-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,34 @@
-version: "3.9"
+version: "3.7"
 services:
-  node:
-    build:
-      context: .
-      dockerfile: Dockerfile
+  caddy:
+    image: lucaslorentz/caddy-docker-proxy:ci-alpine
+    ports:
+      - 80:80
+      - 443:443
+    environment:
+      - CADDY_INGRESS_NETWORKS=caddy
     networks:
-      - zhenxunge-node
+      - caddy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - caddy-data:/data
+    restart: unless-stopped
+
+  node:
+    labels:
+      caddy.reverse_proxy: "{{upstreams 9944}}"
+    image: zhenxunge-node
+    networks:
+      - caddy
     ports:
       - "9944:9944"
     volumes:
       - zhenxunge-node-data:/data
-    deploy:
-      restart_policy:
-        condition: on-failure
-        max_attempts: 10
+    restart: unless-stopped
 
 networks:
-  zhenxunge-node:
+  caddy:
 
 volumes:
   zhenxunge-node-data:
+  caddy-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,22 @@
-version: "3.2"
-
+version: "3.9"
 services:
-  dev:
-    container_name: node-template
-    image: paritytech/ci-linux:974ba3ac-20201006
-    working_dir: /var/www/node-template
+  node:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    networks:
+      - zhenxunge-node
     ports:
       - "9944:9944"
-    environment:
-      - CARGO_HOME=/var/www/node-template/.cargo
     volumes:
-      - .:/var/www/node-template
-      - type: bind
-        source: ./.local
-        target: /root/.local
-    command: bash -c "cargo build --release && ./target/release/node-template --dev --ws-external"
+      - zhenxunge-node-data:/data
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 10
+
+networks:
+  zhenxunge-node:
+
+volumes:
+  zhenxunge-node-data:


### PR DESCRIPTION
This commit adds a Dockerfile which leverages moby's buildkit.
Using buildkit's cache mechanism, we can now incrementally build
container images. Building container images after first attempt is now
very fast.

@xgaozoyoe Can you please check if all the persistent state is saved to `~/.local/share/node-swap`